### PR TITLE
Remove default `lineNumbersMinChars` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.10.0 - Unreleased
+### Changed
+* The default `lineNumbersMinChars` option value is no longer set to `0`.
+
 ## 1.0.9 - 2023.04.16
 ### Changed
 * Updated assets build with the latest deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 1.10.0 - Unreleased
+## 1.0.10 - Unreleased
 ### Changed
 * The default `lineNumbersMinChars` option value is no longer set to `0`.
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "nystudio107/craft-code-editor",
   "description": "Provides a code editor field with Twig & Craft API autocomplete",
   "type": "yii2-extension",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "keywords": [
     "code",
     "editor",

--- a/src/web/assets/src/js/default-monaco-options.ts
+++ b/src/web/assets/src/js/default-monaco-options.ts
@@ -1,5 +1,5 @@
 // The default EditorOptions for the Monaco editor instance
-// ref: https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IEditorOptions.html
+// ref: https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IEditorOptions.html
 import * as monaco from "monaco-editor";
 
 export const defaultMonacoOptions: monaco.editor.IStandaloneEditorConstructionOptions = {

--- a/src/web/assets/src/js/default-monaco-options.ts
+++ b/src/web/assets/src/js/default-monaco-options.ts
@@ -13,7 +13,6 @@ export const defaultMonacoOptions: monaco.editor.IStandaloneEditorConstructionOp
   folding: false,
   // Undocumented see https://github.com/Microsoft/vscode/issues/30795#issuecomment-410998882
   lineDecorationsWidth: 0,
-  lineNumbersMinChars: 0,
   // Disable the current line highlight
   renderLineHighlight: 'none',
   wordWrap: 'on',


### PR DESCRIPTION
Removes the default `lineNumbersMinChars` option value so that the line number gutter gets some spacing.

Fixes https://github.com/nystudio107/craft-code-field/issues/8.