### PR TITLE
Dispose of editor models that already exist when making editor

### DIFF
--- a/src/web/assets/src/js/code-editor.ts
+++ b/src/web/assets/src/js/code-editor.ts
@@ -81,6 +81,7 @@ function makeMonacoEditor(elementId: string, fieldType: string, monacoOptions: s
     modelUri = monaco.Uri.file(fieldOptions.fileName);
     monacoEditorLanguage = undefined;
   }
+  monaco.editor.getModel(modelUri)?.dispose();
   const textModel = monaco.editor.createModel(textArea.value, monacoEditorLanguage, modelUri);
   defaultMonacoOptions.model = textModel;
   // Set the editor theme here, so we don't re-apply it later


### PR DESCRIPTION
### Description

The `makeMonacoEditor` function will trigger an error if it's called with the same elementId.

### Related issues

See https://github.com/nystudio107/craft-code-field/issues/16